### PR TITLE
fixed bug for risk tracker and added test

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -12,10 +12,10 @@ int RiskTracker::updateRisk() {
         if (x.side) {
             runningSum += (x.price * x.quantity);
         } else {
-            runningSum = (x.price * x.quantity);
+            runningSum -= (x.price * x.quantity);
         }
     }
-    this->totalRisk -= runningSum;
+    this->totalRisk = runningSum;
     return 0;
 }
 

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -12,7 +12,7 @@ int RiskTracker::updateRisk() {
         if (x.side) {
             runningSum += (x.price * x.quantity);
         } else {
-            runningSum -= (x.price * x.quantity);
+            runningSum = (x.price * x.quantity);
         }
     }
     this->totalRisk -= runningSum;

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -15,7 +15,7 @@ int RiskTracker::updateRisk() {
             runningSum -= (x.price * x.quantity);
         }
     }
-    this->totalRisk = runningSum;
+    this->totalRisk -= runningSum;
     return 0;
 }
 

--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -15,7 +15,7 @@ int RiskTracker::updateRisk() {
             runningSum -= (x.price * x.quantity);
         }
     }
-    this->totalRisk += runningSum;
+    this->totalRisk = runningSum;
     return 0;
 }
 
@@ -27,4 +27,7 @@ int RiskTracker::addTrade(Trade trade) {
 float RiskTracker::getRisk() {
     return this->totalRisk;
 }
+
+
+
 

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -28,3 +28,19 @@ TEST(TradeRiskTrackerTest, TrackerZeroTest) {
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
 }
+
+TEST(TradeRiskTrackerTest, TrackerOneTest) {
+    std::vector<Trade> trackedTrades;
+    RiskTracker riskTracker(0, trackedTrades);
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
+    riskTracker.addTrade(Trade(100, true, 1.6));
+    EXPECT_NEAR(riskTracker.getRisk(), 0, 1e-4);
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 160, 1e-4);
+    riskTracker.addTrade(Trade(50, false, 1.6));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 80, 1e-4);
+    riskTracker.addTrade(Trade(100, false, 2));
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), -120, 1e-4);
+}


### PR DESCRIPTION
Find the bug in risktracker.cpp, which is that the updateRisk function is incorrectly updating the total risk. I have the running sum replacing the total risk instead of adding to it; wrote a test to cover trades that don’t have risks that just cancel each other out. Struggled with understanding the expected behavior of the function and should probably modify the class so that updateRisk only calculates the new trades added to the vectors instead of recalculating everything again. 